### PR TITLE
Fix token reference error for `v3/send` endpoint

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,7 @@ import {
       const archives = actions
         .filter((it) => it.action === "archive")
         .map((it) => it.item_id);
-      console.log(await Promise.all(archives.map(client.archiveLink)));
+      console.log(await Promise.all(archives.map(client.archiveLink, client)));
 
       res.send({ action_results: [] });
     }


### PR DESCRIPTION
Hi! I noticed an error is thrown when calling the `v3/send` endpoint (when archiving a link):
```
/Users/kuosandys/Documents/KoboOmnivoreConverter-main/lib/omnivoreClient.js:190
                    'Cookie': `auth=${this.token};`,
                                           ^

TypeError: Cannot read properties of undefined (reading 'token')
    at /Users/kuosandys/Documents/KoboOmnivoreConverter-main/lib/omnivoreClient.js:190:44
    at Generator.next (<anonymous>)
    at /Users/kuosandys/Documents/KoboOmnivoreConverter-main/lib/omnivoreClient.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/kuosandys/Documents/KoboOmnivoreConverter-main/lib/omnivoreClient.js:4:12)
    at archiveLink (/Users/kuosandys/Documents/KoboOmnivoreConverter-main/lib/omnivoreClient.js:173:16)
    at Array.map (<anonymous>)
    at /Users/kuosandys/Documents/KoboOmnivoreConverter-main/index.js:48:36
    at Generator.next (<anonymous>)
    at fulfilled (/Users/kuosandys/Documents/KoboOmnivoreConverter-main/index.js:5:58)

Node.js v18.16.0
```

I believe this happens because the reference to `this` is lost when `client.archiveLink` is passed as the `map` callback in the endpoint's handler function. One way this could be fixed is by passing the `client` as the second argument to the `map` function.

By the way, please let me know if I should open an issue for this first - I figured it's a small bug, so just went ahead with a PR 😅 